### PR TITLE
重構: 將所有執行參數移至 appsettings.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,23 +108,41 @@ dotnet test src/tests/ReleaseSync.Integration.Tests/ReleaseSync.Integration.Test
 
 ### 執行應用程式
 
+**重要**: 所有執行參數都從 `appsettings.json` 的 `SyncOptions` 區塊讀取,不再使用命令列參數。
+
 ```bash
 # 從專案根目錄執行 (推薦)
-dotnet run --project src/ReleaseSync.Console -- sync -s 2025-01-01 -e 2025-01-31 --gitlab -o output.json
+# 先在 appsettings.json 中設定 SyncOptions 參數
+dotnet run --project src/ReleaseSync.Console -- sync
 
 # 或從 ReleaseSync.Console 目錄執行
 cd src/ReleaseSync.Console
-dotnet run -- sync -s 2025-01-01 -e 2025-01-31 --gitlab -o output.json
-
-# 啟用 verbose 模式 (Debug 等級日誌)
-dotnet run --project src/ReleaseSync.Console -- sync -s 2025-01-01 -e 2025-01-31 --gitlab -v
-
-# 多平台同步
-dotnet run --project src/ReleaseSync.Console -- sync -s 2025-01-01 -e 2025-01-31 --gitlab --bitbucket --azdo -o output.json
+dotnet run -- sync
 
 # 顯示說明
 dotnet run --project src/ReleaseSync.Console -- --help
 dotnet run --project src/ReleaseSync.Console -- sync --help
+```
+
+**參數設定範例** (appsettings.json):
+
+```json
+{
+  "SyncOptions": {
+    "StartDate": "2025-01-01",
+    "EndDate": "2025-01-31",
+    "EnableGitLab": true,
+    "EnableBitBucket": false,
+    "EnableAzureDevOps": false,
+    "EnableExport": true,
+    "OutputFile": "output.json",
+    "Force": false,
+    "Verbose": false,
+    "EnableGoogleSheet": false,
+    "GoogleSheetId": null,
+    "GoogleSheetName": null
+  }
+}
 ```
 
 ### User Secrets 管理

--- a/README.md
+++ b/README.md
@@ -71,9 +71,26 @@ dotnet build
    ```
 
 5. **執行同步**：
+
+   **重要**: 先在 `config/appsettings.docker.json` 中設定 `SyncOptions` 參數:
+
+   ```json
+   {
+     "SyncOptions": {
+       "StartDate": "2025-01-01",
+       "EndDate": "2025-01-31",
+       "EnableGitLab": true,
+       "EnableExport": true,
+       "OutputFile": "output/result.json"
+     }
+   }
+   ```
+
+   然後執行:
+
    ```bash
-   # 執行同步並輸出到 output/result.json
-   docker compose run --rm releasesync sync -s 2025-01-01 -e 2025-01-31 --gitlab -o output/result.json
+   # 執行同步
+   docker compose run --rm releasesync sync
 
    # 日誌會自動傳送到 Seq，可在 http://localhost:5341 即時檢視
    ```
@@ -82,11 +99,11 @@ dotnet build
 
    ```bash
    # 選項 A: 加上 --build 參數 (一次完成)
-   docker compose run --rm --build releasesync sync -s 2025-01-01 -e 2025-01-31 --gitlab -v
+   docker compose run --rm --build releasesync sync
 
    # 選項 B: 先建置再執行
    docker compose build releasesync
-   docker compose run --rm releasesync sync -s 2025-01-01 -e 2025-01-31 --gitlab -v
+   docker compose run --rm releasesync sync
    ```
 
 ### 3. 本機開發設定
@@ -105,14 +122,27 @@ dotnet user-secrets set "AzureDevOps:PersonalAccessToken" "<YOUR_TOKEN>"
 
 ### 3. 執行
 
+**重要**: 所有執行參數都在 `appsettings.json` 的 `SyncOptions` 區塊中設定。
+
+先在 `appsettings.json` 中設定執行參數:
+
+```json
+{
+  "SyncOptions": {
+    "StartDate": "2025-01-01",
+    "EndDate": "2025-01-31",
+    "EnableGitLab": true,
+    "EnableBitBucket": true,
+    "EnableExport": true,
+    "OutputFile": "output.json"
+  }
+}
+```
+
+然後執行:
+
 ```bash
-dotnet run --project src/ReleaseSync.Console -- sync \
-  --start-date 2025-01-01 \
-  --end-date 2025-01-31 \
-  --enable-gitlab \
-  --enable-bitbucket \
-  --export \
-  --output-file output.json
+dotnet run --project src/ReleaseSync.Console -- sync
 ```
 
 ## 使用範例
@@ -121,71 +151,119 @@ dotnet run --project src/ReleaseSync.Console -- sync \
 
 從 GitLab 抓取過去 30 天的 MR 資訊:
 
+在 `appsettings.json` 中設定:
+
+```json
+{
+  "SyncOptions": {
+    "StartDate": "2025-01-01",
+    "EndDate": "2025-01-31",
+    "EnableGitLab": true
+  }
+}
+```
+
+執行:
+
 ```bash
-dotnet run --project src/ReleaseSync.Console -- sync \
-  -s 2025-01-01 \
-  -e 2025-01-31 \
-  --gitlab
+dotnet run --project src/ReleaseSync.Console -- sync
 ```
 
 ### 匯出 JSON 格式
 
 同時抓取 GitLab 與 BitBucket 並匯出為 JSON:
 
-```bash
-dotnet run --project src/ReleaseSync.Console -- sync \
-  -s 2025-01-01 \
-  -e 2025-01-31 \
-  --gitlab \
-  --bitbucket \
-  --export \
-  -o ./output/sync-result.json
+在 `appsettings.json` 中設定:
+
+```json
+{
+  "SyncOptions": {
+    "StartDate": "2025-01-01",
+    "EndDate": "2025-01-31",
+    "EnableGitLab": true,
+    "EnableBitBucket": true,
+    "EnableExport": true,
+    "OutputFile": "./output/sync-result.json"
+  }
+}
 ```
 
-**注意**: 使用 `--export` 參數啟用 JSON 匯出功能,並透過 `-o` 指定輸出檔案路徑。
+執行:
+
+```bash
+dotnet run --project src/ReleaseSync.Console -- sync
+```
 
 ### Azure DevOps Work Item 整合
 
 啟用 Work Item 整合,從 Branch 名稱解析並抓取 Work Item 資訊:
 
+在 `appsettings.json` 中設定:
+
+```json
+{
+  "SyncOptions": {
+    "StartDate": "2025-01-01",
+    "EndDate": "2025-01-31",
+    "EnableGitLab": true,
+    "EnableAzureDevOps": true,
+    "EnableExport": true,
+    "OutputFile": "./output/full-sync.json",
+    "Verbose": true
+  }
+}
+```
+
+執行:
+
 ```bash
-dotnet run --project src/ReleaseSync.Console -- sync \
-  -s 2025-01-01 \
-  -e 2025-01-31 \
-  --gitlab \
-  --azdo \
-  --export \
-  -o ./output/full-sync.json \
-  --verbose
+dotnet run --project src/ReleaseSync.Console -- sync
 ```
 
 ### Google Sheet 同步
 
 同步資料到 Google Sheet (需先設定服務帳號憑證):
 
-```bash
-dotnet run --project src/ReleaseSync.Console -- sync \
-  -s 2025-01-01 \
-  -e 2025-01-31 \
-  --gitlab \
-  --bitbucket \
-  --google-sheet
+在 `appsettings.json` 中設定:
+
+```json
+{
+  "SyncOptions": {
+    "StartDate": "2025-01-01",
+    "EndDate": "2025-01-31",
+    "EnableGitLab": true,
+    "EnableBitBucket": true,
+    "EnableGoogleSheet": true
+  }
+}
 ```
 
-## 命令列參數
+執行:
 
-| 參數 | 別名 | 說明 |
+```bash
+dotnet run --project src/ReleaseSync.Console -- sync
+```
+
+## 執行參數設定
+
+**重要變更**: 所有執行參數現在都在 `appsettings.json` 的 `SyncOptions` 區塊中設定,不再使用命令列參數。
+
+### SyncOptions 參數說明
+
+| 參數 | 型別 | 說明 |
 |------|------|------|
-| `--start-date` | `-s` | 查詢起始日期 (必填) |
-| `--end-date` | `-e` | 查詢結束日期 (必填) |
-| `--enable-gitlab` | `--gitlab` | 啟用 GitLab 平台 |
-| `--enable-bitbucket` | `--bitbucket` | 啟用 BitBucket 平台 |
-| `--enable-azure-devops` | `--azdo` | 啟用 Azure DevOps Work Item 整合 |
-| `--enable-export` | `--export` | 啟用 JSON 匯出功能 |
-| `--output-file` | `-o` | JSON 匯出檔案路徑 |
-| `--force` | `-f` | 強制覆蓋已存在的輸出檔案 |
-| `--verbose` | `-v` | 啟用詳細日誌輸出 (Debug 等級) |
-| `--enable-google-sheet` | `--google-sheet` | 啟用 Google Sheet 同步功能 |
+| `StartDate` | DateTime | 查詢起始日期 (包含) |
+| `EndDate` | DateTime | 查詢結束日期 (包含) |
+| `EnableGitLab` | bool | 啟用 GitLab 平台 |
+| `EnableBitBucket` | bool | 啟用 BitBucket 平台 |
+| `EnableAzureDevOps` | bool | 啟用 Azure DevOps Work Item 整合 |
+| `EnableExport` | bool | 啟用 JSON 匯出功能 |
+| `OutputFile` | string? | JSON 匯出檔案路徑 |
+| `Force` | bool | 強制覆蓋已存在的輸出檔案 |
+| `Verbose` | bool | 啟用詳細日誌輸出 (Debug 等級) |
+| `EnableGoogleSheet` | bool | 啟用 Google Sheet 同步功能 |
+| `GoogleSheetId` | string? | Google Sheet ID (覆蓋 GoogleSheet 設定) |
+| `GoogleSheetName` | string? | Google Sheet 工作表名稱 |
 
 ## 組態設定
 

--- a/src/ReleaseSync.Console/Commands/SyncCommand.cs
+++ b/src/ReleaseSync.Console/Commands/SyncCommand.cs
@@ -5,6 +5,9 @@ namespace ReleaseSync.Console.Commands;
 /// <summary>
 /// 同步 PR/MR 資訊的命令定義
 /// </summary>
+/// <remarks>
+/// 所有執行參數都從 appsettings.json 的 SyncOptions 區塊讀取,不再使用命令列參數
+/// </remarks>
 public static class SyncCommand
 {
     /// <summary>
@@ -13,80 +16,10 @@ public static class SyncCommand
     /// <returns>Sync 命令物件</returns>
     public static Command Create()
     {
-        var command = new Command("sync", "從版控平台同步 PR/MR 資訊");
+        var command = new Command("sync", "從版控平台同步 PR/MR 資訊 (所有參數從 appsettings.json 讀取)");
 
-        // 必填參數
-        var startDateOption = new Option<DateTime>(
-            aliases: new[] { "--start-date", "-s" },
-            description: "查詢起始日期 (包含)");
-        startDateOption.IsRequired = true;
-
-        var endDateOption = new Option<DateTime>(
-            aliases: new[] { "--end-date", "-e" },
-            description: "查詢結束日期 (包含)");
-        endDateOption.IsRequired = true;
-
-        // 平台啟用選項
-        var enableGitLabOption = new Option<bool>(
-            aliases: new[] { "--enable-gitlab", "--gitlab" },
-            getDefaultValue: () => false,
-            description: "啟用 GitLab 平台");
-
-        var enableBitBucketOption = new Option<bool>(
-            aliases: new[] { "--enable-bitbucket", "--bitbucket" },
-            getDefaultValue: () => false,
-            description: "啟用 BitBucket 平台");
-
-        var enableAzureDevOpsOption = new Option<bool>(
-            aliases: new[] { "--enable-azure-devops", "--azdo" },
-            getDefaultValue: () => false,
-            description: "啟用 Azure DevOps Work Item 整合");
-
-        // 匯出選項
-        var enableExportOption = new Option<bool>(
-            aliases: new[] { "--enable-export", "--export" },
-            getDefaultValue: () => false,
-            description: "啟用 JSON 匯出功能");
-
-        var outputFileOption = new Option<string?>(
-            aliases: new[] { "--output-file", "-o" },
-            description: "JSON 匯出檔案路徑");
-
-        var forceOption = new Option<bool>(
-            aliases: new[] { "--force", "-f" },
-            getDefaultValue: () => false,
-            description: "強制覆蓋已存在的輸出檔案");
-
-        var verboseOption = new Option<bool>(
-            aliases: new[] { "--verbose", "-v" },
-            getDefaultValue: () => false,
-            description: "啟用詳細日誌輸出");
-
-        var enableGoogleSheetOption = new Option<bool>(
-            aliases: new[] { "--enable-google-sheet", "--google-sheet" },
-            getDefaultValue: () => false,
-            description: "啟用 Google Sheet 同步功能");
-
-        var googleSheetIdOption = new Option<string?>(
-            aliases: new[] { "--google-sheet-id", "--sheet-id" },
-            description: "Google Sheet ID (覆蓋 appsettings.json 設定)");
-
-        var googleSheetNameOption = new Option<string?>(
-            aliases: new[] { "--google-sheet-name", "--sheet-name" },
-            description: "Google Sheet 工作表名稱 (預設: Sheet1)");
-
-        command.AddOption(startDateOption);
-        command.AddOption(endDateOption);
-        command.AddOption(enableGitLabOption);
-        command.AddOption(enableBitBucketOption);
-        command.AddOption(enableAzureDevOpsOption);
-        command.AddOption(enableExportOption);
-        command.AddOption(outputFileOption);
-        command.AddOption(forceOption);
-        command.AddOption(verboseOption);
-        command.AddOption(enableGoogleSheetOption);
-        command.AddOption(googleSheetIdOption);
-        command.AddOption(googleSheetNameOption);
+        // 所有參數已移至 appsettings.json 的 SyncOptions 區塊
+        // 不再接受命令列參數
 
         return command;
     }

--- a/src/ReleaseSync.Console/Program.cs
+++ b/src/ReleaseSync.Console/Program.cs
@@ -2,12 +2,14 @@ using System.CommandLine;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using ReleaseSync.Application.Exporters;
 using ReleaseSync.Application.Importers;
 using ReleaseSync.Application.Services;
 using ReleaseSync.Console.Commands;
 using ReleaseSync.Console.Handlers;
 using ReleaseSync.Console.Services;
+using ReleaseSync.Infrastructure.Configuration;
 using ReleaseSync.Infrastructure.DependencyInjection;
 using Serilog;
 
@@ -17,22 +19,23 @@ class Program
 {
     static async Task<int> Main(string[] args)
     {
-        // 檢查是否有 --verbose 參數以設定日誌等級
-        var verbose = args.Contains("--verbose") || args.Contains("-v");
-
         // 建立設定
         var configuration = new ConfigurationBuilder()
             .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
             .AddUserSecrets<Program>(optional: true)
             .Build();
 
+        // 從組態讀取 SyncOptions
+        var syncOptionsSettings = new SyncOptionsSettings();
+        configuration.GetSection("SyncOptions").Bind(syncOptionsSettings);
+
         // 讀取 Seq 設定
         var seqServerUrl = configuration["Seq:ServerUrl"] ?? Environment.GetEnvironmentVariable("SEQ_SERVER_URL");
         var seqApiKey = configuration["Seq:ApiKey"];
 
-        // 設定 Serilog (根據 verbose 參數設定日誌等級)
+        // 設定 Serilog (根據組態中的 Verbose 設定日誌等級)
         var loggerConfig = new LoggerConfiguration()
-            .MinimumLevel.Is(verbose ? Serilog.Events.LogEventLevel.Debug : Serilog.Events.LogEventLevel.Information)
+            .MinimumLevel.Is(syncOptionsSettings.Verbose ? Serilog.Events.LogEventLevel.Debug : Serilog.Events.LogEventLevel.Information)
             .Enrich.FromLogContext()
             .WriteTo.Console();
 
@@ -60,11 +63,14 @@ class Program
             services.AddLogging(builder =>
             {
                 builder.AddSerilog(dispose: true);
-                builder.SetMinimumLevel(verbose ? LogLevel.Debug : LogLevel.Information);
+                builder.SetMinimumLevel(syncOptionsSettings.Verbose ? LogLevel.Debug : LogLevel.Information);
             });
 
             // 註冊 Configuration
             services.AddSingleton<IConfiguration>(configuration);
+
+            // 註冊 SyncOptions 配置
+            services.AddSyncOptions(configuration);
 
             // 註冊 Infrastructure 平台服務 (使用 Extension Methods)
             services.AddGitLabServices(configuration);
@@ -90,39 +96,27 @@ class Program
             // 建立 RootCommand
             var rootCommand = new RootCommand("ReleaseSync - PR/MR 變更資訊聚合工具");
 
-            // 加入 sync 命令
+            // 加入 sync 命令 (無參數,所有設定從 appsettings.json 讀取)
             var syncCommand = SyncCommand.Create();
             rootCommand.AddCommand(syncCommand);
 
-            // 設定 handler
-            syncCommand.SetHandler(async (context) =>
+            // 設定 handler - 從組態檔讀取所有參數
+            syncCommand.SetHandler(async () =>
             {
                 var options = new SyncCommandOptions
                 {
-                    StartDate = context.ParseResult.GetValueForOption(
-                        syncCommand.Options.OfType<Option<DateTime>>().First(o => o.HasAlias("-s"))),
-                    EndDate = context.ParseResult.GetValueForOption(
-                        syncCommand.Options.OfType<Option<DateTime>>().First(o => o.HasAlias("-e"))),
-                    EnableGitLab = context.ParseResult.GetValueForOption(
-                        syncCommand.Options.OfType<Option<bool>>().First(o => o.HasAlias("--gitlab"))),
-                    EnableBitBucket = context.ParseResult.GetValueForOption(
-                        syncCommand.Options.OfType<Option<bool>>().First(o => o.HasAlias("--bitbucket"))),
-                    EnableAzureDevOps = context.ParseResult.GetValueForOption(
-                        syncCommand.Options.OfType<Option<bool>>().First(o => o.HasAlias("--azdo"))),
-                    EnableExport = context.ParseResult.GetValueForOption(
-                        syncCommand.Options.OfType<Option<bool>>().First(o => o.HasAlias("--export"))),
-                    OutputFile = context.ParseResult.GetValueForOption(
-                        syncCommand.Options.OfType<Option<string?>>().First(o => o.HasAlias("-o"))),
-                    Force = context.ParseResult.GetValueForOption(
-                        syncCommand.Options.OfType<Option<bool>>().First(o => o.HasAlias("-f"))),
-                    Verbose = context.ParseResult.GetValueForOption(
-                        syncCommand.Options.OfType<Option<bool>>().First(o => o.HasAlias("-v"))),
-                    EnableGoogleSheet = context.ParseResult.GetValueForOption(
-                        syncCommand.Options.OfType<Option<bool>>().First(o => o.HasAlias("--google-sheet"))),
-                    GoogleSheetId = context.ParseResult.GetValueForOption(
-                        syncCommand.Options.OfType<Option<string?>>().First(o => o.HasAlias("--google-sheet-id"))),
-                    GoogleSheetName = context.ParseResult.GetValueForOption(
-                        syncCommand.Options.OfType<Option<string?>>().First(o => o.HasAlias("--google-sheet-name")))
+                    StartDate = syncOptionsSettings.StartDate,
+                    EndDate = syncOptionsSettings.EndDate,
+                    EnableGitLab = syncOptionsSettings.EnableGitLab,
+                    EnableBitBucket = syncOptionsSettings.EnableBitBucket,
+                    EnableAzureDevOps = syncOptionsSettings.EnableAzureDevOps,
+                    EnableExport = syncOptionsSettings.EnableExport,
+                    OutputFile = syncOptionsSettings.OutputFile,
+                    Force = syncOptionsSettings.Force,
+                    Verbose = syncOptionsSettings.Verbose,
+                    EnableGoogleSheet = syncOptionsSettings.EnableGoogleSheet,
+                    GoogleSheetId = syncOptionsSettings.GoogleSheetId,
+                    GoogleSheetName = syncOptionsSettings.GoogleSheetName
                 };
 
                 using var scope = serviceProvider.CreateScope();

--- a/src/ReleaseSync.Console/appsettings.json
+++ b/src/ReleaseSync.Console/appsettings.json
@@ -1,5 +1,19 @@
 {
   "$schema": "./appsettings-schema.json",
+  "SyncOptions": {
+    "StartDate": "2025-01-01",
+    "EndDate": "2025-01-31",
+    "EnableGitLab": false,
+    "EnableBitBucket": false,
+    "EnableAzureDevOps": false,
+    "EnableExport": false,
+    "OutputFile": null,
+    "Force": false,
+    "Verbose": false,
+    "EnableGoogleSheet": false,
+    "GoogleSheetId": null,
+    "GoogleSheetName": null
+  },
   "GitLab": {
     "ApiUrl": "https://gitlab.com/api/v4",
     "Projects": [

--- a/src/ReleaseSync.Infrastructure/Configuration/SyncOptionsSettings.cs
+++ b/src/ReleaseSync.Infrastructure/Configuration/SyncOptionsSettings.cs
@@ -1,0 +1,67 @@
+namespace ReleaseSync.Infrastructure.Configuration;
+
+/// <summary>
+/// Sync 命令執行參數設定
+/// </summary>
+public class SyncOptionsSettings
+{
+    /// <summary>
+    /// 查詢起始日期 (包含)
+    /// </summary>
+    public DateTime StartDate { get; set; }
+
+    /// <summary>
+    /// 查詢結束日期 (包含)
+    /// </summary>
+    public DateTime EndDate { get; set; }
+
+    /// <summary>
+    /// 是否啟用 GitLab 平台
+    /// </summary>
+    public bool EnableGitLab { get; set; }
+
+    /// <summary>
+    /// 是否啟用 BitBucket 平台
+    /// </summary>
+    public bool EnableBitBucket { get; set; }
+
+    /// <summary>
+    /// 是否啟用 Azure DevOps Work Item 整合
+    /// </summary>
+    public bool EnableAzureDevOps { get; set; }
+
+    /// <summary>
+    /// 是否啟用 JSON 匯出功能
+    /// </summary>
+    public bool EnableExport { get; set; }
+
+    /// <summary>
+    /// JSON 匯出檔案路徑
+    /// </summary>
+    public string? OutputFile { get; set; }
+
+    /// <summary>
+    /// 是否強制覆蓋已存在的輸出檔案
+    /// </summary>
+    public bool Force { get; set; }
+
+    /// <summary>
+    /// 是否啟用詳細日誌輸出
+    /// </summary>
+    public bool Verbose { get; set; }
+
+    /// <summary>
+    /// 是否啟用 Google Sheet 同步功能
+    /// </summary>
+    public bool EnableGoogleSheet { get; set; }
+
+    /// <summary>
+    /// Google Sheet ID (覆蓋 GoogleSheet:SpreadsheetId 設定)
+    /// </summary>
+    public string? GoogleSheetId { get; set; }
+
+    /// <summary>
+    /// Google Sheet 工作表名稱 (預設: Sheet1)
+    /// </summary>
+    public string? GoogleSheetName { get; set; }
+}

--- a/src/ReleaseSync.Infrastructure/DependencyInjection/SyncOptionsServiceCollectionExtensions.cs
+++ b/src/ReleaseSync.Infrastructure/DependencyInjection/SyncOptionsServiceCollectionExtensions.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using ReleaseSync.Infrastructure.Configuration;
+
+namespace ReleaseSync.Infrastructure.DependencyInjection;
+
+/// <summary>
+/// SyncOptions 服務註冊擴展方法
+/// </summary>
+public static class SyncOptionsServiceCollectionExtensions
+{
+    /// <summary>
+    /// 註冊 SyncOptions 配置服務
+    /// </summary>
+    /// <param name="services">服務集合</param>
+    /// <param name="configuration">組態物件</param>
+    /// <returns>服務集合</returns>
+    public static IServiceCollection AddSyncOptions(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.Configure<SyncOptionsSettings>(
+            configuration.GetSection("SyncOptions"));
+
+        return services;
+    }
+}

--- a/src/tests/ReleaseSync.Infrastructure.UnitTests/Configuration/SyncOptionsSettingsTests.cs
+++ b/src/tests/ReleaseSync.Infrastructure.UnitTests/Configuration/SyncOptionsSettingsTests.cs
@@ -1,0 +1,119 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using ReleaseSync.Infrastructure.Configuration;
+
+namespace ReleaseSync.Infrastructure.UnitTests.Configuration;
+
+/// <summary>
+/// SyncOptionsSettings 單元測試
+/// </summary>
+public class SyncOptionsSettingsTests
+{
+    /// <summary>
+    /// 測試應正確從組態檔綁定所有必要屬性
+    /// </summary>
+    [Fact]
+    public void SyncOptionsSettings_Should_Bind_All_Properties_From_Configuration()
+    {
+        // Arrange
+        var configurationData = new Dictionary<string, string?>
+        {
+            ["SyncOptions:StartDate"] = "2025-01-01",
+            ["SyncOptions:EndDate"] = "2025-01-31",
+            ["SyncOptions:EnableGitLab"] = "true",
+            ["SyncOptions:EnableBitBucket"] = "false",
+            ["SyncOptions:EnableAzureDevOps"] = "true",
+            ["SyncOptions:EnableExport"] = "true",
+            ["SyncOptions:OutputFile"] = "output.json",
+            ["SyncOptions:Force"] = "false",
+            ["SyncOptions:Verbose"] = "true",
+            ["SyncOptions:EnableGoogleSheet"] = "true",
+            ["SyncOptions:GoogleSheetId"] = "1A2B3C4D5E6F",
+            ["SyncOptions:GoogleSheetName"] = "Release Log"
+        };
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configurationData)
+            .Build();
+
+        // Act
+        var settings = new SyncOptionsSettings();
+        configuration.GetSection("SyncOptions").Bind(settings);
+
+        // Assert
+        settings.StartDate.Should().Be(new DateTime(2025, 1, 1));
+        settings.EndDate.Should().Be(new DateTime(2025, 1, 31));
+        settings.EnableGitLab.Should().BeTrue();
+        settings.EnableBitBucket.Should().BeFalse();
+        settings.EnableAzureDevOps.Should().BeTrue();
+        settings.EnableExport.Should().BeTrue();
+        settings.OutputFile.Should().Be("output.json");
+        settings.Force.Should().BeFalse();
+        settings.Verbose.Should().BeTrue();
+        settings.EnableGoogleSheet.Should().BeTrue();
+        settings.GoogleSheetId.Should().Be("1A2B3C4D5E6F");
+        settings.GoogleSheetName.Should().Be("Release Log");
+    }
+
+    /// <summary>
+    /// 測試當未提供可選參數時,應使用預設值
+    /// </summary>
+    [Fact]
+    public void SyncOptionsSettings_Should_Use_Default_Values_When_Not_Provided()
+    {
+        // Arrange
+        var configurationData = new Dictionary<string, string?>
+        {
+            ["SyncOptions:StartDate"] = "2025-01-01",
+            ["SyncOptions:EndDate"] = "2025-01-31"
+        };
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configurationData)
+            .Build();
+
+        // Act
+        var settings = new SyncOptionsSettings();
+        configuration.GetSection("SyncOptions").Bind(settings);
+
+        // Assert
+        settings.StartDate.Should().Be(new DateTime(2025, 1, 1));
+        settings.EndDate.Should().Be(new DateTime(2025, 1, 31));
+        settings.EnableGitLab.Should().BeFalse(); // 預設值
+        settings.EnableBitBucket.Should().BeFalse();
+        settings.EnableAzureDevOps.Should().BeFalse();
+        settings.EnableExport.Should().BeFalse();
+        settings.OutputFile.Should().BeNull();
+        settings.Force.Should().BeFalse();
+        settings.Verbose.Should().BeFalse();
+        settings.EnableGoogleSheet.Should().BeFalse();
+        settings.GoogleSheetId.Should().BeNull();
+        settings.GoogleSheetName.Should().BeNull();
+    }
+
+    /// <summary>
+    /// 測試應正確處理日期時間格式
+    /// </summary>
+    [Fact]
+    public void SyncOptionsSettings_Should_Parse_DateTime_Correctly()
+    {
+        // Arrange
+        var configurationData = new Dictionary<string, string?>
+        {
+            ["SyncOptions:StartDate"] = "2025-06-15T10:30:00",
+            ["SyncOptions:EndDate"] = "2025-12-31T23:59:59"
+        };
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configurationData)
+            .Build();
+
+        // Act
+        var settings = new SyncOptionsSettings();
+        configuration.GetSection("SyncOptions").Bind(settings);
+
+        // Assert
+        settings.StartDate.Should().Be(new DateTime(2025, 6, 15, 10, 30, 0));
+        settings.EndDate.Should().Be(new DateTime(2025, 12, 31, 23, 59, 59));
+    }
+}


### PR DESCRIPTION
- 新增 SyncOptionsSettings 配置類別
- 新增 SyncOptionsServiceCollectionExtensions DI 擴展方法
- 重構 Program.cs 從配置檔讀取參數,移除命令列參數解析
- 簡化 SyncCommand 為無參數命令
- 更新 appsettings.json 新增 SyncOptions 區塊
- 新增單元測試 SyncOptionsSettingsTests
- 更新 CLAUDE.md 與 README.md 文件說明

此變更符合 Issue #9 需求,所有執行參數現在統一在 appsettings.json 中設定, 不再使用命令列參數,提供更一致的配置管理方式。

🤖 Generated with [Claude Code](https://claude.com/claude-code)